### PR TITLE
Fix issue #1

### DIFF
--- a/minigeth/core/state/state_object.go
+++ b/minigeth/core/state/state_object.go
@@ -354,11 +354,10 @@ func (s *stateObject) updateTrie(db Database) Trie {
 		s.originStorage[key] = value
 
 		var v []byte
-		oracle.PrefetchStorage(db.BlockNumber, s.address, key)
-		// Get absense proof of current key in case the deletion make the extension node to short node.
-		oracle.PrefetchStorage(big.NewInt(db.BlockNumber.Int64()+1), s.address, key)
 		if (value == common.Hash{}) {
 			//fmt.Println("delete", s.address, key)
+			// Get absense proof of key in case the deletion needs the sister node.
+			oracle.PrefetchStorage(big.NewInt(db.BlockNumber.Int64()+1), s.address, key)
 			s.setError(tr.TryDelete(key[:]))
 		} else {
 			//fmt.Println("update", s.address, key, value)

--- a/minigeth/core/state/state_object.go
+++ b/minigeth/core/state/state_object.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/oracle"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
 )
 
 var emptyCodeHash = crypto.Keccak256(nil)
@@ -248,7 +249,7 @@ func (s *stateObject) GetCommittedState(db Database, key common.Hash) common.Has
 		if metrics.EnabledExpensive {
 			meter = &s.db.StorageReads
 		}
-		oracle.PrefetchStorage(db.BlockNumber, s.address, key)
+		oracle.PrefetchStorage(db.BlockNumber, s.address, key, nil)
 		if enc, err = s.getTrie(db).TryGet(key.Bytes()); err != nil {
 			s.setError(err)
 			return common.Hash{}
@@ -357,7 +358,7 @@ func (s *stateObject) updateTrie(db Database) Trie {
 		if (value == common.Hash{}) {
 			//fmt.Println("delete", s.address, key)
 			// Get absense proof of key in case the deletion needs the sister node.
-			oracle.PrefetchStorage(big.NewInt(db.BlockNumber.Int64()+1), s.address, key)
+			oracle.PrefetchStorage(big.NewInt(db.BlockNumber.Int64()+1), s.address, key, trie.GenPossibleShortNodePreimage)
 			s.setError(tr.TryDelete(key[:]))
 		} else {
 			//fmt.Println("update", s.address, key, value)

--- a/minigeth/core/state/state_object.go
+++ b/minigeth/core/state/state_object.go
@@ -355,7 +355,8 @@ func (s *stateObject) updateTrie(db Database) Trie {
 
 		var v []byte
 		oracle.PrefetchStorage(db.BlockNumber, s.address, key)
-		//oracle.PrefetchStorage(big.NewInt(db.BlockNumber.Int64()+1), s.address, key)
+		// Get absense proof of current key in case the deletion make the extension node to short node.
+		oracle.PrefetchStorage(big.NewInt(db.BlockNumber.Int64()+1), s.address, key)
 		if (value == common.Hash{}) {
 			//fmt.Println("delete", s.address, key)
 			s.setError(tr.TryDelete(key[:]))

--- a/minigeth/core/state/statedb.go
+++ b/minigeth/core/state/statedb.go
@@ -456,6 +456,8 @@ func (s *StateDB) deleteStateObject(obj *stateObject) {
 	}
 	// Delete the account from the trie
 	addr := obj.Address()
+	// Get absense proof of account in case the deletion needs the sister node.
+	oracle.PrefetchAccount(big.NewInt(s.db.BlockNumber.Int64()+1), addr)
 	if err := s.trie.TryDelete(addr[:]); err != nil {
 		s.setError(fmt.Errorf("deleteStateObject (%x) error: %v", addr[:], err))
 	}

--- a/minigeth/core/state/statedb.go
+++ b/minigeth/core/state/statedb.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/oracle"
 	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/ethereum/go-ethereum/trie"
 )
 
 // for includes we don't have
@@ -457,7 +458,7 @@ func (s *StateDB) deleteStateObject(obj *stateObject) {
 	// Delete the account from the trie
 	addr := obj.Address()
 	// Get absense proof of account in case the deletion needs the sister node.
-	oracle.PrefetchAccount(big.NewInt(s.db.BlockNumber.Int64()+1), addr)
+	oracle.PrefetchAccount(big.NewInt(s.db.BlockNumber.Int64()+1), addr, trie.GenPossibleShortNodePreimage)
 	if err := s.trie.TryDelete(addr[:]); err != nil {
 		s.setError(fmt.Errorf("deleteStateObject (%x) error: %v", addr[:], err))
 	}
@@ -515,7 +516,7 @@ func (s *StateDB) getDeletedStateObject(addr common.Address) *stateObject {
 		if metrics.EnabledExpensive {
 			defer func(start time.Time) { s.AccountReads += time.Since(start) }(time.Now())
 		}
-		oracle.PrefetchAccount(s.db.BlockNumber, addr)
+		oracle.PrefetchAccount(s.db.BlockNumber, addr, nil)
 		enc, err := s.trie.TryGet(addr.Bytes())
 		if err != nil {
 			s.setError(fmt.Errorf("getDeleteStateObject (%x) error: %v", addr.Bytes(), err))

--- a/minigeth/oracle/embedded_mips.go
+++ b/minigeth/oracle/embedded_mips.go
@@ -41,6 +41,6 @@ func Preimage(hash common.Hash) []byte {
 }
 
 // these are stubs in embedded world
-func PrefetchStorage(blockNumber *big.Int, addr common.Address, skey common.Hash) {}
-func PrefetchAccount(blockNumber *big.Int, addr common.Address)                   {}
-func PrefetchCode(blockNumber *big.Int, addrHash common.Hash)                     {}
+func PrefetchStorage(*big.Int, common.Address, common.Hash, func(map[common.Hash][]byte)) {}
+func PrefetchAccount(*big.Int, common.Address, func(map[common.Hash][]byte))              {}
+func PrefetchCode(*big.Int, common.Hash)                                                  {}

--- a/minigeth/oracle/prefetch.go
+++ b/minigeth/oracle/prefetch.go
@@ -108,7 +108,7 @@ func unhash(addrHash common.Hash) common.Address {
 
 var cached = make(map[string]bool)
 
-func PrefetchStorage(blockNumber *big.Int, addr common.Address, skey common.Hash) {
+func PrefetchStorage(blockNumber *big.Int, addr common.Address, skey common.Hash, postProcess func(map[common.Hash][]byte)) {
 	key := fmt.Sprintf("proof_%d_%s_%s", blockNumber, addr, skey)
 	if cached[key] {
 		return
@@ -117,15 +117,24 @@ func PrefetchStorage(blockNumber *big.Int, addr common.Address, skey common.Hash
 
 	ap := getProofAccount(blockNumber, addr, skey, true)
 	//fmt.Println("PrefetchStorage", blockNumber, addr, skey, len(ap))
+	newPreimages := make(map[common.Hash][]byte)
 	for _, s := range ap {
 		ret, _ := hex.DecodeString(s[2:])
 		hash := crypto.Keccak256Hash(ret)
 		//fmt.Println("   ", i, hash)
-		preimages[hash] = ret
+		newPreimages[hash] = ret
+	}
+
+	if postProcess != nil {
+		postProcess(newPreimages)
+	}
+
+	for hash, val := range newPreimages {
+		preimages[hash] = val
 	}
 }
 
-func PrefetchAccount(blockNumber *big.Int, addr common.Address) {
+func PrefetchAccount(blockNumber *big.Int, addr common.Address, postProcess func(map[common.Hash][]byte)) {
 	key := fmt.Sprintf("proof_%d_%s", blockNumber, addr)
 	if cached[key] {
 		return
@@ -133,10 +142,19 @@ func PrefetchAccount(blockNumber *big.Int, addr common.Address) {
 	cached[key] = true
 
 	ap := getProofAccount(blockNumber, addr, common.Hash{}, false)
+	newPreimages := make(map[common.Hash][]byte)
 	for _, s := range ap {
 		ret, _ := hex.DecodeString(s[2:])
 		hash := crypto.Keccak256Hash(ret)
-		preimages[hash] = ret
+		newPreimages[hash] = ret
+	}
+
+	if postProcess != nil {
+		postProcess(newPreimages)
+	}
+
+	for hash, val := range newPreimages {
+		preimages[hash] = val
 	}
 }
 

--- a/minigeth/oracle/preimage.go
+++ b/minigeth/oracle/preimage.go
@@ -18,7 +18,6 @@ func Preimage(hash common.Hash) []byte {
 	ioutil.WriteFile(key, val, 0644)
 	if !ok {
 		fmt.Println("can't find preimage", hash)
-		panic("preimage missing")
 	}
 	return val
 }

--- a/minigeth/oracle/preimage.go
+++ b/minigeth/oracle/preimage.go
@@ -22,3 +22,8 @@ func Preimage(hash common.Hash) []byte {
 	}
 	return val
 }
+
+// TODO: Maybe we will want to have a seperate preimages for next block's preimages?
+func Preimages() map[common.Hash][]byte {
+	return preimages
+}

--- a/minigeth/trie/trie.go
+++ b/minigeth/trie/trie.go
@@ -443,16 +443,10 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 				// might not be loaded yet, resolve it just for this
 				// check.
 
-				// TODO: Try to cache short nodes already generated
-				genPossibleShortNodePreimage(pos)
-
-				// TODO: We might want to ignore this error and remove the panic in oracle.Preimage
-				//       in case the sister node in deletion is an extension node.
-				// remove this optimisticly? if it's not a shortNode, it doesn't do anything
-				cnode, err := t.resolve(n.Children[pos], prefix)
-				if err != nil {
-					return false, nil, err
-				}
+				// When node is not resolved in next block's absence proof,
+				// it must be an extension node if the state transition is
+				// valid, so we ignore the error here.
+				cnode, _ := t.resolve(n.Children[pos], prefix)
 				if cnode, ok := cnode.(*shortNode); ok {
 					k := append([]byte{byte(pos)}, cnode.Key...)
 					return true, &shortNode{k, cnode.Val, t.newFlag()}, nil

--- a/minigeth/trie/trie.go
+++ b/minigeth/trie/trie.go
@@ -445,6 +445,9 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 
 				// TODO: Try to cache short nodes already generated
 				genPossibleShortNodePreimage(pos)
+
+				// TODO: We might want to ignore this error and remove the panic in oracle.Preimage
+				//       in case the sister node in deletion is an extension node.
 				// remove this optimisticly? if it's not a shortNode, it doesn't do anything
 				cnode, err := t.resolve(n.Children[pos], prefix)
 				if err != nil {

--- a/minigeth/trie/trie.go
+++ b/minigeth/trie/trie.go
@@ -443,6 +443,8 @@ func (t *Trie) delete(n node, prefix, key []byte) (bool, node, error) {
 				// might not be loaded yet, resolve it just for this
 				// check.
 
+				// TODO: Try to cache short nodes already generated
+				genPossibleShortNodePreimage(pos)
 				// remove this optimisticly? if it's not a shortNode, it doesn't do anything
 				cnode, err := t.resolve(n.Children[pos], prefix)
 				if err != nil {


### PR DESCRIPTION
Since the deletion fails when sister node is a short node, which means the short node will definitely be in next block's absence proof but with longer prefix, if the deletion is indeed applied to the next block.

This PR's strategy is to get the absence proof and brute-forcely enumerate all pairs in preimages to find the missing short nodes to generate the possible short node pairs for trie deletion usage.