### PR TITLE
Fix: set missing difficulty in block header

### DIFF
--- a/minigeth/main.go
+++ b/minigeth/main.go
@@ -68,6 +68,8 @@ func main() {
 	processor := core.NewStateProcessor(params.MainnetChainConfig, bc, bc.Engine())
 	fmt.Println("processing state:", parent.Number, "->", newheader.Number)
 
+	newheader.Difficulty = bc.Engine().CalcDifficulty(bc, newheader.Time, &parent)
+
 	// read txs
 	//traverseStackTrie(newheader.TxHash)
 

--- a/minigeth/oracle/prefetch.go
+++ b/minigeth/oracle/prefetch.go
@@ -197,7 +197,7 @@ func Output(output common.Hash) {
 	if output == inputs[6] {
 		fmt.Println("good transition")
 	} else {
-		fmt.Println(output, "!=", inputs[5])
+		fmt.Println(output, "!=", inputs[6])
 		panic("BAD transition :((")
 	}
 }

--- a/minigeth/oracle/preimage.go
+++ b/minigeth/oracle/preimage.go
@@ -21,7 +21,7 @@ func Preimage(hash common.Hash) []byte {
 		fmt.Println("can't find preimage", hash)
 	}
 	comphash := crypto.Keccak256Hash(val)
-	if hash != comphash {
+	if ok && hash != comphash {
 		panic("corruption in hash " + hash.String())
 	}
 	return val


### PR DESCRIPTION
Resolves #8. Was worried when I saw missing preimage again, then actually it's just another missing piece in header, phew.

Just peeked #9 and found it fails because some txs try to read historical block hash but the `Blockchain` only has its parent's hash, it should prepare historical 256 block hash for opcode `BLOCKHASH`.
