### PR TITLE
Fix typo in log statement

### DIFF
--- a/minigeth/main.go
+++ b/minigeth/main.go
@@ -47,7 +47,7 @@ func main() {
 		oracle.PrefetchBlock(big.NewInt(int64(blockNumber)+1), false, pkwtrie)
 		hash, err := pkwtrie.Commit()
 		check(err)
-		fmt.Println("commited transactions", hash, err)
+		fmt.Println("committed transactions", hash, err)
 	}
 
 	// init secp256k1BytePoints


### PR DESCRIPTION
Noticed when running locally.
