### PR TITLE
Interfaces refactor & fix Solidity function name conventions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 artifacts
 cache
+bin

--- a/contracts/interfaces/IMIPS.sol
+++ b/contracts/interfaces/IMIPS.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.3;
+
+import "./IMIPSMemory.sol";
+
+/**
+ * @dev Interface for the implemented MIPS (Microprocessor without Interlocked Pipelined Stages) architecture.
+ */
+interface IMIPS {
+    // TODO: Reflect all implemented functions.
+
+    /**
+     * @dev Returns the state hash as bytes32.
+     */
+    function step(bytes32 stateHash) external view returns (bytes32);
+    
+    /**
+     * @dev Returns the MIPS memory.
+     * See {IMIPSMemory.sol}.
+     */
+    function m() external pure returns (IMIPSMemory);
+
+    // TODO: Reflect all implemented events.
+}

--- a/contracts/interfaces/IMIPSMemory.sol
+++ b/contracts/interfaces/IMIPSMemory.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.7.3;
+
+/**
+ * @dev Interface for the read and write functionality of the MIPS (Microprocessor without Interlocked Pipelined Stages) memory.
+ */
+interface IMIPSMemory {
+    // TODO: Reflect all implemented functions.
+    
+    /**
+     * @dev Returns the MIPS memory as unit32 value type.
+     */
+    function readMemory(bytes32 stateHash, uint32 addr) external view returns (uint32);
+
+    /**
+     * @dev Returns the MIPS memory bytes as bytes32 value type.
+     */
+    function readBytes32(bytes32 stateHash, uint32 addr) external view returns (bytes32);
+
+    /**
+     * @dev Writes the MIPS memory.
+     */
+    function writeMemory(bytes32 stateHash, uint32 addr, uint32 val) external pure returns (bytes32);
+
+    // TODO: Reflect all implemented events.
+}


### PR DESCRIPTION
Following the Solidity best practices, I refactored the interfaces as separate `.sol` files and implemented the mixedCase naming for functions (https://docs.soliditylang.org/en/v0.8.7/style-guide.html#function-names). 