### PR TITLE
Remove transfer in favour of call

### DIFF
--- a/contracts/Challenge.sol
+++ b/contracts/Challenge.sol
@@ -50,7 +50,8 @@ contract Challenge {
   receive() external payable {}
   function withdraw() external {
     require(msg.sender == owner);
-    owner.transfer(address(this).balance);
+    (bool success, ) = owner.call{ value: address(this).balance }("");
+    require(success, "Withdraw failed");
   }
 
   // create challenge
@@ -214,7 +215,8 @@ contract Challenge {
     require(stepState == c.assertedState[c.R], "wrong asserted state for challenger");
 
     // pay out bounty!!
-    c.challenger.transfer(address(this).balance);
+    (bool success, ) = c.challenger.call{ value: address(this).balance }("");
+    require(success, "Failed to pay bounty");
     
     emit ChallengerWins(challengeId);
   }


### PR DESCRIPTION
This PR removes the use of `<address>.transfer()` from the `Challenge` contract, in favour of `<address>.call()`. See [here](https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now) for why this might be useful.